### PR TITLE
Update builder.toml

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -1,4 +1,4 @@
-description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Java, Go, Python, Apache HTTPD, NGINX and Procfile"
+description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apache HTTPD, Go, Java, Java Native Image, .NET, NGINX, Node.js, PHP, Procfile, Python, and Ruby"
 
 [[buildpacks]]
   uri = "docker://gcr.io/paketo-buildpacks/dotnet-core:0.39.0"


### PR DESCRIPTION
## Summary
I submitted a similar PR ([#365](https://github.com/paketo-buildpacks/builder-jammy-full/pull/365)) to update the list of supported stacks for this build.  I just noticed that this list is also in the `builder.toml` file and updated it as well.

## Use Cases
The `builder.toml` description is omitting stacks that this builder supports, which can be misleading to users. This just happened to me as I ran `pack builder suggest`.

## Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
