### PR TITLE
Pin GitHub Actions to digests

### DIFF
--- a/.github/workflows/approve-bot-pr.yml
+++ b/.github/workflows/approve-bot-pr.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Checkout
       if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Approve
       if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,12 +15,12 @@ jobs:
       release_notes: ${{ steps.notes.outputs.body }}
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
       with:
         go-version: 'stable'
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Get pack version
       id: pack-version
@@ -54,7 +54,7 @@ jobs:
     needs: smoke
     steps:
     - name: Checkout With History
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         fetch-depth: 0  # gets full history
 
@@ -71,7 +71,7 @@ jobs:
     - name: Publish Release
       id: publish
       if: ${{ steps.compare_previous_release.outputs.builder_changes == 'true' }}
-      uses: release-drafter/release-drafter@v5
+      uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
       with:
         config-name: release-drafter-config.yml
         publish: true

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -10,16 +10,16 @@ jobs:
   lintYaml:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Checkout github-config
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         repository: paketo-buildpacks/github-config
         path: github-config
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -17,7 +17,7 @@ jobs:
         echo "tag=$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)" >> "$GITHUB_OUTPUT"
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Get pack version
       id: pack-version

--- a/.github/workflows/synchronize-labels.yml
+++ b/.github/workflows/synchronize-labels.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on:
             - ubuntu-22.04
         steps:
-            - uses: actions/checkout@v3
-            - uses: micnncim/action-label-syncer@v1
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1
               env:
                   GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test-builder.yml
+++ b/.github/workflows/test-builder.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
       with:
         go-version: 'stable'
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Run Smoke Tests
       run: ./scripts/smoke.sh

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
       with:
         go-version: 'stable'
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Run Smoke Tests
       run: ./scripts/smoke.sh
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Upload Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
       with:
         name: event-payload
         path: ${{ github.event_path }}

--- a/.github/workflows/update-builder-toml.yml
+++ b/.github/workflows/update-builder-toml.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Checkout branch
       uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main

--- a/.github/workflows/update-github-config.yml
+++ b/.github/workflows/update-github-config.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
     - name: Checkout github-config
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         repository: paketo-buildpacks/github-config
         path: github-config

--- a/.github/workflows/update-go-mod-version.yml
+++ b/.github/workflows/update-go-mod-version.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Checkout PR Branch
         uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
         with:
           branch: automation/go-mod-update/update-main
       - name: Setup Go
         id: setup-go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
           go-version: 'stable'
       - name: Get current go toolchain version


### PR DESCRIPTION
Hey there 👋

I work on an open source security project ([Frizbee](https://github.com/stacklok/frizbee)) that can automatically pin GitHub Actions to digests (instead of floating tags). 

The Frizbee team is trying to spread the word to open source maintainers about the need for this, because pinning your actions to commit hashes is the *only* way to get an immutable pointer to a specific revision. If an action's source code repo is compromised by a malicious actor, you'll still be referencing a known-good version and your project won't be at risk. 

The following PR pins your actions to their commit hash and it was done using the [frizbee](https://github.com/stacklok/frizbee) CLI. Frizbee also appends a comment so you can easily see which version this digest corresponds to.

Note that Dependabot supports updating pinned actions and will continue to update them.

If you liked it and also want to keep this consistent in case you add more unpinned actions in future, there's a [frizbee-action](https://github.com/stacklok/frizbee-action) which you can use to help automate this.

Thanks!
