### PR TITLE
Changing pull policy during tests to always

### DIFF
--- a/smoke/dotnet_test.go
+++ b/smoke/dotnet_test.go
@@ -56,7 +56,7 @@ func testDotnet(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithPullPolicy("never").
+				WithPullPolicy("always").
 				WithBuilder(Builder).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)

--- a/smoke/go_test.go
+++ b/smoke/go_test.go
@@ -56,7 +56,7 @@ func testGo(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithPullPolicy("never").
+				WithPullPolicy("always").
 				WithBuilder(Builder).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)

--- a/smoke/java_native_image_test.go
+++ b/smoke/java_native_image_test.go
@@ -56,7 +56,7 @@ func testJavaNativeImage(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithPullPolicy("never").
+				WithPullPolicy("always").
 				WithBuilder(Builder).
 				WithEnv(map[string]string{
 					"BP_NATIVE_IMAGE":          "true",

--- a/smoke/java_test.go
+++ b/smoke/java_test.go
@@ -57,7 +57,7 @@ func testJava(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithPullPolicy("never").
+				WithPullPolicy("always").
 				WithBuilder(Builder).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)

--- a/smoke/nodejs_test.go
+++ b/smoke/nodejs_test.go
@@ -56,7 +56,7 @@ func testNodejs(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithPullPolicy("never").
+				WithPullPolicy("always").
 				WithBuilder(Builder).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)

--- a/smoke/php_test.go
+++ b/smoke/php_test.go
@@ -56,7 +56,7 @@ func testPhp(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithPullPolicy("never").
+				WithPullPolicy("always").
 				WithEnv(map[string]string{
 					"BP_PHP_WEB_DIR": "htdocs",
 				}).

--- a/smoke/procfile_test.go
+++ b/smoke/procfile_test.go
@@ -56,7 +56,7 @@ func testProcfile(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithPullPolicy("never").
+				WithPullPolicy("always").
 				WithBuilder(Builder).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)

--- a/smoke/python_test.go
+++ b/smoke/python_test.go
@@ -56,7 +56,7 @@ func testPython(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithPullPolicy("never").
+				WithPullPolicy("always").
 				WithBuilder(Builder).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)

--- a/smoke/ruby_test.go
+++ b/smoke/ruby_test.go
@@ -56,7 +56,7 @@ func testRuby(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithPullPolicy("never").
+				WithPullPolicy("always").
 				WithBuilder(Builder).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)

--- a/smoke/web_servers_test.go
+++ b/smoke/web_servers_test.go
@@ -56,7 +56,7 @@ func testWebServers(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithPullPolicy("never").
+				WithPullPolicy("always").
 				WithBuilder(Builder).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)
@@ -102,7 +102,7 @@ func testWebServers(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.Build.
-				WithPullPolicy("never").
+				WithPullPolicy("always").
 				WithBuilder(Builder).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)
@@ -149,7 +149,7 @@ func testWebServers(t *testing.T, context spec.G, it spec.S) {
 
 				var logs fmt.Stringer
 				image, logs, err = pack.Build.
-					WithPullPolicy("never").
+					WithPullPolicy("always").
 					WithBuilder(Builder).
 					WithEnv(map[string]string{
 						"BP_NODE_RUN_SCRIPTS":             "build",
@@ -183,7 +183,7 @@ func testWebServers(t *testing.T, context spec.G, it spec.S) {
 
 				var logs fmt.Stringer
 				image, logs, err = pack.Build.
-					WithPullPolicy("never").
+					WithPullPolicy("always").
 					WithBuilder(Builder).
 					WithEnv(map[string]string{
 						"BP_NODE_RUN_SCRIPTS":             "build",


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR changes pull policy for the builder to always. This is necessary for the multi-arch tests, as the builder is being published to a registry and is no longer available to the docker daemon registry, as a result, the tests will fail

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).